### PR TITLE
Language selection

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -6,6 +6,13 @@ website:
   sidebar:
     collapse-level: 1
     contents:
+      - text: |
+            <div id="sidebar-content">
+              <select id="language-selector">
+                <option value="pymc">PyMC</option>
+                <option value="stan">Stan</option>
+              </select>
+            </div>
       - section: "Regression"
         contents:
           - gen_linear_regression/gen_linear_regression_overview.qmd
@@ -58,6 +65,9 @@ website:
 format:
   html:
     theme: cosmo
+    include-after-body: 
+    - text: |
+          <script src="/scripts/language_select.js"></script>
     css: styles.css
     toc: true
     code-fold: true

--- a/gen_linear_regression/bernoulli_logit.qmd
+++ b/gen_linear_regression/bernoulli_logit.qmd
@@ -62,9 +62,11 @@ logis_sigma <- function(n, q) {
 
 $p(\alpha) \propto \exp{(-\text{abs}({\alpha / \sqrt(2) \sigma})^\gamma)}$
 
+:::{.example .stan}
 ```stan
 target += -abs((alpha) / (sqrt(2.0) * alpha_scale))^(alpha_power);
 ```
+:::
 
 Similar to the method for the logistic prior, choosing $\sigma$ can be
 done with the following function:

--- a/gen_linear_regression/gr2.qmd
+++ b/gen_linear_regression/gr2.qmd
@@ -37,7 +37,9 @@ Priors on $\alpha$ and $\sigma$. Hyperparameters $\xi$, $\mu_{R^2}$, $\phi_{R^2}
 
 Prior on simplex $\phi$.
 
-# Stan code
+# Implementation
 
+::: {.example .stan}
 ```{.stan include="../stan/r2d2.stan"}
 ```
+:::

--- a/gen_linear_regression/l1_ball.qmd
+++ b/gen_linear_regression/l1_ball.qmd
@@ -21,7 +21,9 @@ $$
 Prior on the radius of the ball $r$. Prior on the unprojected $\beta$
 coefficients.
 
-# Stan code
+# Implementation
 
+::: {.example .stan}
 ```{.stan include="../stan/l1_ball.stan"}
 ```
+:::

--- a/gen_linear_regression/r2d2.qmd
+++ b/gen_linear_regression/r2d2.qmd
@@ -36,7 +36,12 @@ $$
 
 Priors on $\alpha$ and $\sigma$. Hyperparameters $\xi$, $\mu_{R^2}$, $\phi_{R^2}$. 
 
-# Stan code
-
+# Implementation
+::: {.example .stan}
 ```{.stan include="../stan/r2d2.stan"}
 ```
+:::
+
+::: {.example .pymc}
+
+:::

--- a/hierarchical_regression/r2d2m2.qmd
+++ b/hierarchical_regression/r2d2m2.qmd
@@ -8,7 +8,9 @@ An extension of the R2D2 prior for multi-level models [@aguilarIntuitiveJointPri
 
 # Definition
 
-# Stan code
+# Implementation
 
+:::{.example .stan}
 ```{.stan include="../stan/r2d2m2.stan"}
 ```
+:::

--- a/scripts/language_select.js
+++ b/scripts/language_select.js
@@ -1,0 +1,31 @@
+document.addEventListener("DOMContentLoaded", function() {
+  const langSelector = document.getElementById("language-selector");
+
+  // Load the selected language from localStorage if available
+  const savedLang = localStorage.getItem("selectedLanguage");
+  if (savedLang) {
+    langSelector.value = savedLang;
+  }
+
+  // Function to show/hide code examples based on the selected language
+  function updateExamples() {
+    const selectedLang = langSelector.value;
+
+    // Save the selected language to localStorage
+    localStorage.setItem("selectedLanguage", selectedLang);
+
+    document.querySelectorAll(".example").forEach(function(example) {
+      if (example.classList.contains(selectedLang)) {
+        example.style.display = "block";
+      } else {
+        example.style.display = "none";
+      }
+    });
+  }
+
+  // Listen for changes in the dropdown menu
+  langSelector.addEventListener("change", updateExamples);
+
+  // Initialize by showing the appropriate examples when the page loads
+  updateExamples();
+});


### PR DESCRIPTION
This adds a simple drop down in the sidebar that can be used to select either Stan or PyMC. The examples will then be shown in that language.

Currently there are no pymc examples though